### PR TITLE
Players with points always lose at least 1 point in Chaos Space events

### DIFF
--- a/src/app/gm-tools/feature/chaos-space-event-page.component.ts
+++ b/src/app/gm-tools/feature/chaos-space-event-page.component.ts
@@ -669,7 +669,10 @@ export default class ChaosSpaceEventPageComponent {
       map(([percentageLoss, players]) =>
         players!.map((player) => ({
           ...player,
-          scoreChange: Math.round((percentageLoss / -100) * player.score),
+          scoreChange: Math.min(
+            player.score ? -1 : 0,
+            Math.round((percentageLoss / -100) * player.score),
+          ),
         })),
       ),
     ),
@@ -731,7 +734,10 @@ export default class ChaosSpaceEventPageComponent {
         players!.map((player) => ({
           ...player,
           scoreChange: playerIdsWhoFailedTask.includes(player.player_id)
-            ? Math.round((percentageLoss / -100) * player.score)
+            ? Math.min(
+                player.score ? -1 : 0,
+                Math.round((percentageLoss / -100) * player.score),
+              )
             : 0,
         })),
       ),


### PR DESCRIPTION
Closes #57