### PR TITLE
feat(auth): add confirm (magic link) page and password reset page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,21 +1,11 @@
 import { Routes } from '@angular/router';
-import {
-  redirectLoggedInToHomePage,
-  redirectUnauthorizedToLoginPage,
-} from './auth/data-access/auth.guard';
+import { redirectUnauthorizedToLoginPage } from './auth/data-access/auth.guard';
 import { canAccessGmTools } from './auth/data-access/auth.gm.guard';
 
 export const routes: Routes = [
   {
-    path: 'login',
-    loadComponent: () =>
-      import('./auth/feature/login-page/login-page.component'),
-    canActivate: [redirectLoggedInToHomePage],
-  },
-  {
-    path: 'auth/confirm',
-    loadComponent: () =>
-      import('./auth/feature/confirm-page/confirm-page.component'),
+    path: 'auth',
+    loadChildren: () => import('./auth/feature/lib.routes'),
   },
   {
     path: 'dashboard',
@@ -53,14 +43,6 @@ export const routes: Routes = [
       {
         path: 'profile',
         loadChildren: () => import('./profile/feature/lib.routes'),
-      },
-      {
-        path: 'auth/reset-password',
-        loadComponent: () =>
-          import(
-            './auth/feature/reset-password-page/reset-password-page.component'
-          ),
-        canActivate: [redirectUnauthorizedToLoginPage],
       },
       {
         path: '**',

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,11 @@ export const routes: Routes = [
     canActivate: [redirectLoggedInToHomePage],
   },
   {
+    path: 'auth/confirm',
+    loadComponent: () =>
+      import('./auth/feature/confirm-page/confirm-page.component'),
+  },
+  {
     path: 'dashboard',
     loadComponent: () => import('./dashboard/feature/dashboard-page.component'),
     canActivate: [redirectUnauthorizedToLoginPage],
@@ -48,6 +53,14 @@ export const routes: Routes = [
       {
         path: 'profile',
         loadChildren: () => import('./profile/feature/lib.routes'),
+      },
+      {
+        path: 'auth/reset-password',
+        loadComponent: () =>
+          import(
+            './auth/feature/reset-password-page/reset-password-page.component'
+          ),
+        canActivate: [redirectUnauthorizedToLoginPage],
       },
       {
         path: '**',

--- a/src/app/auth/data-access/auth.guard.ts
+++ b/src/app/auth/data-access/auth.guard.ts
@@ -26,7 +26,7 @@ function createAuthGuardFromRedirectFunction(
 }
 
 export const redirectUnauthorizedToLoginPage =
-  createAuthGuardFromRedirectFunction((user) => !!user || '/login');
+  createAuthGuardFromRedirectFunction((user) => !!user || '/auth/login');
 
 export const redirectLoggedInToHomePage = createAuthGuardFromRedirectFunction(
   (user) => (!!user && '/') || true,

--- a/src/app/auth/feature/confirm-page/confirm-page.component.ts
+++ b/src/app/auth/feature/confirm-page/confirm-page.component.ts
@@ -1,0 +1,55 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject, Input, OnInit, signal } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+@Component({
+  selector: 'joshies-confirm-page',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="mt-3">
+      {{ error() || 'Confirming...' }}
+    </div>
+  `,
+  styles: ``,
+})
+export default class ConfirmPageComponent implements OnInit {
+  private readonly supabase = inject(SupabaseClient);
+
+  @Input() token_hash!: string;
+  @Input() redirect_to?: string;
+
+  error = signal('');
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {}
+
+  async verify() {
+    const token_hash = this.token_hash;
+    const type = 'magiclink';
+    const { error } = await this.supabase.auth.verifyOtp({
+      token_hash,
+      type,
+    });
+    if (error) {
+      this.error.set(error.message + '; Redirecting in 5 seconds...');
+      setTimeout(() => this.router.navigate(['/']), 5000);
+    } else if (this.redirect_to) {
+      this.router.navigate(['/' + this.redirect_to]);
+    } else {
+      this.router.navigate(['/']);
+    }
+  }
+
+  ngOnInit() {
+    if (!this.token_hash) {
+      this.error.set('No token provided. Redirecting in 3 seconds...');
+      setTimeout(() => this.router.navigate(['/']), 3000);
+      return;
+    }
+    this.verify();
+  }
+}

--- a/src/app/auth/feature/confirm-page/confirm-page.component.ts
+++ b/src/app/auth/feature/confirm-page/confirm-page.component.ts
@@ -1,51 +1,43 @@
-import { CommonModule } from '@angular/common';
-import { Component, inject, Input, OnInit, signal } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component, inject, input, OnInit, signal } from '@angular/core';
+import { Router } from '@angular/router';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 @Component({
   selector: 'joshies-confirm-page',
   standalone: true,
-  imports: [CommonModule],
-  template: `
-    <div class="mt-3">
-      {{ error() || 'Confirming...' }}
-    </div>
-  `,
-  styles: ``,
+  imports: [],
+  template: `{{ error() || 'Confirming...' }}`,
+  host: {
+    class: 'block mt-3',
+  },
 })
 export default class ConfirmPageComponent implements OnInit {
   private readonly supabase = inject(SupabaseClient);
+  private readonly router = inject(Router);
 
-  @Input() token_hash!: string;
-  @Input() redirect_to?: string;
+  readonly token_hash = input.required<string>();
+  readonly redirect_to = input.required<string>();
 
-  error = signal('');
+  readonly error = signal<string | null>(null);
 
-  constructor(
-    private route: ActivatedRoute,
-    private router: Router,
-  ) {}
-
-  async verify() {
-    const token_hash = this.token_hash;
-    const type = 'magiclink';
+  async verify(): Promise<void> {
     const { error } = await this.supabase.auth.verifyOtp({
-      token_hash,
-      type,
+      token_hash: this.token_hash(),
+      type: 'magiclink',
     });
+
     if (error) {
       this.error.set(error.message + '; Redirecting in 5 seconds...');
       setTimeout(() => this.router.navigate(['/']), 5000);
-    } else if (this.redirect_to) {
-      this.router.navigate(['/' + this.redirect_to]);
+    } else if (this.redirect_to()) {
+      void this.router.navigate(['/' + this.redirect_to()]);
     } else {
-      this.router.navigate(['/']);
+      void this.router.navigate(['/']);
     }
   }
 
   ngOnInit() {
-    if (!this.token_hash) {
+    if (!this.token_hash()) {
       this.error.set('No token provided. Redirecting in 3 seconds...');
       setTimeout(() => this.router.navigate(['/']), 3000);
       return;

--- a/src/app/auth/feature/lib.routes.ts
+++ b/src/app/auth/feature/lib.routes.ts
@@ -1,0 +1,25 @@
+import { Routes } from '@angular/router';
+import {
+  redirectLoggedInToHomePage,
+  redirectUnauthorizedToLoginPage,
+} from '../data-access/auth.guard';
+
+const authRoutes: Routes = [
+  {
+    path: 'login',
+    loadComponent: () => import('./login-page/login-page.component'),
+    canActivate: [redirectLoggedInToHomePage],
+  },
+  {
+    path: 'reset-password',
+    loadComponent: () =>
+      import('./reset-password-page/reset-password-page.component'),
+    canActivate: [redirectUnauthorizedToLoginPage],
+  },
+  {
+    path: 'confirm',
+    loadComponent: () => import('./confirm-page/confirm-page.component'),
+  },
+];
+
+export default authRoutes;

--- a/src/app/auth/feature/reset-password-page/reset-password-page.component.ts
+++ b/src/app/auth/feature/reset-password-page/reset-password-page.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import {
   AbstractControl,
@@ -16,50 +15,49 @@ import { InputTextModule } from 'primeng/inputtext';
 @Component({
   selector: 'joshies-reset-password-page',
   standalone: true,
-  imports: [CommonModule, InputTextModule, ButtonModule, ReactiveFormsModule],
+  imports: [InputTextModule, ButtonModule, ReactiveFormsModule],
   template: `
-    <div
-      class="h-full flex flex-column justify-content-center align-items-center"
+    <form
+      [formGroup]="form"
+      (ngSubmit)="onSubmit()"
+      class="w-full max-w-30rem flex flex-column gap-3 px-3"
     >
-      <form
-        [formGroup]="form"
-        (ngSubmit)="onSubmit()"
-        class="w-full max-w-30rem flex flex-column gap-3 px-3"
-      >
-        <input
-          pInputText
-          type="password"
-          placeholder="New Password"
-          [formControl]="form.controls.newPassword"
-        />
+      <input
+        pInputText
+        type="password"
+        placeholder="New Password"
+        [formControl]="form.controls.newPassword"
+      />
 
-        <input
-          pInputText
-          type="password"
-          placeholder="Confirm New Password"
-          [formControl]="form.controls.confirmNewPassword"
-        />
+      <input
+        pInputText
+        type="password"
+        placeholder="Confirm New Password"
+        [formControl]="form.controls.confirmNewPassword"
+      />
 
-        <p-button
-          styleClass="w-full"
-          type="submit"
-          [disabled]="!form.valid"
-          label="Reset Password"
-        />
+      <p-button
+        styleClass="w-full"
+        type="submit"
+        [disabled]="!form.valid"
+        label="Reset Password"
+      />
 
-        @if (form.invalid) {
-          @if (
-            newPassword?.errors?.['minlength'] ||
-            newPassword?.errors?.['maxlength']
-          ) {
-            <div>Password must be between 8 and 20 characters.</div>
-          } @else if (form.errors?.['passwordsMustMatch']) {
-            <div>Passwords do not match.</div>
-          }
+      @if (form.invalid) {
+        @if (
+          newPassword?.errors?.['minlength'] ||
+          newPassword?.errors?.['maxlength']
+        ) {
+          <div>Password must be between 8 and 20 characters.</div>
+        } @else if (form.errors?.['passwordsMustMatch']) {
+          <div>Passwords do not match.</div>
         }
-      </form>
-    </div>
+      }
+    </form>
   `,
+  host: {
+    class: 'h-full flex flex-column justify-content-center align-items-center',
+  },
 })
 export default class ResetPasswordPageComponent {
   private readonly formBuilder = inject(FormBuilder);
@@ -99,9 +97,11 @@ export default class ResetPasswordPageComponent {
 
   async onSubmit(): Promise<void> {
     const { newPassword } = this.form.getRawValue();
+
     const { error } = await this.supabase.auth.updateUser({
       password: newPassword,
     });
+
     if (error) {
       this.messageService.add({ detail: error.message, severity: 'error' });
     } else {

--- a/src/app/auth/feature/reset-password-page/reset-password-page.component.ts
+++ b/src/app/auth/feature/reset-password-page/reset-password-page.component.ts
@@ -1,0 +1,122 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { Router } from '@angular/router';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { MessageService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+
+@Component({
+  selector: 'joshies-reset-password-page',
+  standalone: true,
+  imports: [CommonModule, InputTextModule, ButtonModule, ReactiveFormsModule],
+  template: `
+    <div
+      class="h-full flex flex-column justify-content-center align-items-center"
+    >
+      <form
+        [formGroup]="form"
+        (ngSubmit)="onSubmit()"
+        class="w-full max-w-30rem flex flex-column gap-3 px-3"
+      >
+        <input
+          pInputText
+          type="password"
+          placeholder="New Password"
+          [formControl]="form.controls.newPassword"
+        />
+
+        <input
+          pInputText
+          type="password"
+          placeholder="Confirm New Password"
+          [formControl]="form.controls.confirmNewPassword"
+        />
+
+        <p-button
+          styleClass="w-full"
+          type="submit"
+          [disabled]="!form.valid"
+          label="Reset Password"
+        />
+
+        @if (form.invalid) {
+          @if (
+            newPassword?.errors?.['minlength'] ||
+            newPassword?.errors?.['maxlength']
+          ) {
+            <div>Password must be between 8 and 20 characters.</div>
+          } @else if (form.errors?.['passwordsMustMatch']) {
+            <div>Passwords do not match.</div>
+          }
+        }
+      </form>
+    </div>
+  `,
+})
+export default class ResetPasswordPageComponent {
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly supabase = inject(SupabaseClient);
+  private readonly messageService = inject(MessageService);
+  private readonly router = inject(Router);
+
+  readonly form = this.formBuilder.nonNullable.group(
+    {
+      newPassword: [
+        '',
+        [
+          Validators.required,
+          Validators.minLength(8),
+          Validators.maxLength(20),
+        ],
+      ],
+      confirmNewPassword: [
+        '',
+        [
+          Validators.required,
+          Validators.minLength(8),
+          Validators.maxLength(20),
+        ],
+      ],
+    },
+    { validators: [stringsMatchValidator] },
+  );
+
+  get newPassword() {
+    return this.form.get('newPassword');
+  }
+
+  get confirmNewPassword() {
+    return this.form.get('confirmNewPassword');
+  }
+
+  async onSubmit(): Promise<void> {
+    const { newPassword } = this.form.getRawValue();
+    const { error } = await this.supabase.auth.updateUser({
+      password: newPassword,
+    });
+    if (error) {
+      this.messageService.add({ detail: error.message, severity: 'error' });
+    } else {
+      this.messageService.add({
+        detail: 'Password changed',
+        severity: 'success',
+      });
+      this.router.navigate(['/']);
+    }
+  }
+}
+
+function stringsMatchValidator(c: AbstractControl): ValidationErrors | null {
+  if (c.get('newPassword')?.value !== c.get('confirmNewPassword')?.value) {
+    return { passwordsMustMatch: true };
+  }
+  return null;
+}


### PR DESCRIPTION
Password reset requests can be sent from supabase. They contain a magic link for signing in, and a redirect to the new password reset page. When logged in, the password reset page can also be accessed directly from /auth/reset-password. For future work, we can consider adding a reset password button on the login screen.