### PR TITLE
Manual duel creation/cancellation

### DIFF
--- a/src/app/gm-tools/feature/duel-page.component.ts
+++ b/src/app/gm-tools/feature/duel-page.component.ts
@@ -628,7 +628,7 @@ export default class DuelPageComponent {
   ): void {
     confirmBackendAction({
       action: async () => this.duelService.cancelDuel(duelId),
-      confirmationMessageText: `Are you sure you cancel ${displayName}'s duel? This cannot be undone.`,
+      confirmationMessageText: `Are you sure you want to cancel ${displayName}'s duel? This cannot be undone.`,
       successMessageText: 'Duel canceled',
       submittingSignal: this.cancelingDuel,
       confirmationService: this.confirmationService,

--- a/src/app/gm-tools/feature/gm-tools-page.component.ts
+++ b/src/app/gm-tools/feature/gm-tools-page.component.ts
@@ -172,6 +172,11 @@ export default class GmToolsPageComponent {
       iconClass: 'pi pi-flag bg-purple-500',
       routerLink: './events',
     },
+    {
+      text: 'Manage Duels',
+      iconClass: 'pi pi-star bg-pink-500',
+      routerLink: './manage-duels',
+    },
   ];
 
   readonly gameboardLinks: CardLinkModel[] = [

--- a/src/app/gm-tools/feature/lib.routes.ts
+++ b/src/app/gm-tools/feature/lib.routes.ts
@@ -77,7 +77,11 @@ const gmToolsRoutes: Routes = [
     loadComponent: () => import('./duel-page.component'),
     data: { pageAnimationLayer: 3 },
   },
-
+  {
+    path: 'manage-duels',
+    loadComponent: () => import('./manage-duels-page.component'),
+    data: { pageAnimationLayer: 1 },
+  },
   {
     path: 'resolve-chaos-space-events',
     loadComponent: () => import('./resolve-chaos-space-events-page.component'),

--- a/src/app/gm-tools/feature/manage-duels-page.component.ts
+++ b/src/app/gm-tools/feature/manage-duels-page.component.ts
@@ -1,0 +1,100 @@
+import { Component, computed, inject, Signal } from '@angular/core';
+import { PageHeaderComponent } from '../../shared/ui/page-header.component';
+import { HeaderLinkComponent } from '../../shared/ui/header-link.component';
+import NewDuelComponent from '../ui/new-duel.component';
+import { DuelStatus } from '../../shared/util/supabase-helpers';
+import { DuelModel } from '../../shared/util/supabase-types';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { DuelService } from '../../shared/data-access/duel.service';
+import { GameStateService } from '../../shared/data-access/game-state.service';
+import { DuelsTableComponent } from '../ui/duels-table.component';
+
+@Component({
+  selector: 'joshies-manage-duels-page',
+  template: ` <joshies-page-header headerText="Manage Duels" alwaysSmall>
+      <joshies-header-link
+        text="GM Tools"
+        routerLink=".."
+        chevronDirection="left"
+      />
+    </joshies-page-header>
+    <div class="mt-8">
+      <p class="font-bold">Create a new duel</p>
+      <joshies-new-duel />
+      @if (roundNumber(); as roundNumber) {
+        @if (duelsForThisTurn(); as duelsForThisTurn) {
+          <p class="my-8 font-bold">
+            Unresolved duels for turn {{ roundNumber }}
+          </p>
+
+          @if (duelsForThisTurn.length) {
+            <joshies-duels-table
+              [duels]="duelsForThisTurn"
+              [cancelable]="true"
+            />
+          } @else {
+            <p class="my-2 py-2 text-left text-neutral-500 italic">None</p>
+          }
+        }
+        @if (duelsForNextTurn(); as duelsForNextTurn) {
+          <p class="my-8 font-bold">
+            Unresolved duels for turn {{ roundNumber + 1 }}
+          </p>
+
+          @if (duelsForNextTurn.length) {
+            <joshies-duels-table [duels]="duelsForNextTurn" />
+          } @else {
+            <p class="my-2 py-2 text-left text-neutral-500 italic">
+              None... yet!
+            </p>
+          }
+        }
+      }
+    </div>`,
+  imports: [
+    PageHeaderComponent,
+    HeaderLinkComponent,
+    NewDuelComponent,
+    DuelsTableComponent,
+  ],
+})
+export default class ManageDuelsPageComponent {
+  private readonly duelService = inject(DuelService);
+  private readonly gameStateService = inject(GameStateService);
+
+  private readonly duels: Signal<DuelModel[] | undefined> = toSignal(
+    this.duelService.duelsForThisTurn$,
+  );
+
+  readonly roundNumber = this.gameStateService.roundNumber;
+
+  readonly duelsForThisTurn = computed(() => {
+    const roundNumber = this.roundNumber();
+    const duels = this.duels();
+    if (!duels || !roundNumber) {
+      return [];
+    }
+    return duels.filter(
+      (duel) =>
+        duel.round_number === roundNumber &&
+        duel.status !== DuelStatus.Canceled &&
+        duel.status !== DuelStatus.ChallengerWon &&
+        duel.status !== DuelStatus.OpponentWon,
+    );
+  });
+
+  readonly duelsForNextTurn = computed(() => {
+    const roundNumber = this.roundNumber();
+    const duels = this.duels();
+    if (!duels || !roundNumber) {
+      return [];
+    }
+    return duels.filter(
+      (duel) =>
+        duel.round_number === roundNumber + 1 &&
+        duel.status !== DuelStatus.Canceled &&
+        duel.status !== DuelStatus.ChallengerWon &&
+        duel.status !== DuelStatus.OpponentWon,
+    );
+  });
+}

--- a/src/app/gm-tools/feature/resolve-duels-page.component.ts
+++ b/src/app/gm-tools/feature/resolve-duels-page.component.ts
@@ -13,21 +13,15 @@ import {
   RoundPhase,
   trackById,
 } from '../../shared/util/supabase-helpers';
-import { AvatarModule } from 'primeng/avatar';
 import { SkeletonModule } from 'primeng/skeleton';
-import { SelectButtonModule } from 'primeng/selectbutton';
-import { FormsModule } from '@angular/forms';
-import { TableModule } from 'primeng/table';
-import { StronglyTypedTableRowDirective } from '../../shared/ui/strongly-typed-table-row.directive';
 import { GameStateService } from '../../shared/data-access/game-state.service';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { StatusTagComponent } from '../ui/status-tag.component';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { confirmBackendAction } from '../../shared/util/dialog-helpers';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { DuelService } from '../../shared/data-access/duel.service';
 import { DuelModel } from '../../shared/util/supabase-types';
-import { DuelTableAvatarsComponent } from '../../shared/ui/duel-table-avatars.component';
+import { DuelsTableComponent } from '../ui/duels-table.component';
 
 @Component({
   selector: 'joshies-resolve-duels-page',
@@ -35,15 +29,9 @@ import { DuelTableAvatarsComponent } from '../../shared/ui/duel-table-avatars.co
     HeaderLinkComponent,
     PageHeaderComponent,
     ButtonModule,
-    AvatarModule,
     SkeletonModule,
-    SelectButtonModule,
-    FormsModule,
-    TableModule,
-    StronglyTypedTableRowDirective,
-    StatusTagComponent,
     RouterLink,
-    DuelTableAvatarsComponent,
+    DuelsTableComponent,
   ],
   template: `
     <joshies-page-header headerText="Duels" alwaysSmall>
@@ -58,33 +46,7 @@ import { DuelTableAvatarsComponent } from '../../shared/ui/duel-table-avatars.co
       <p class="mt-8">Duels for turn {{ roundNumber() }}</p>
 
       @if (duels.length) {
-        <p-table [value]="duels" [rowTrackBy]="trackById">
-          <ng-template #header>
-            <tr>
-              <th class="pr-0">Players</th>
-              <th>Game</th>
-              <th class="px-0 text-right">Status</th>
-              <th class="px-0"></th>
-            </tr>
-          </ng-template>
-
-          <ng-template #body let-duel [joshiesStronglyTypedTableRow]="duels">
-            <tr [routerLink]="[duel.id]">
-              <td class="pr-0">
-                <joshies-duel-table-avatars [duel]="duel" />
-              </td>
-              <td class="text-sm">
-                {{ duel.game_name }}
-              </td>
-              <td class="px-0 text-right">
-                <joshies-status-tag [status]="duel.status" />
-              </td>
-              <td class="px-1">
-                <i class="pi pi-angle-right text-neutral-400"></i>
-              </td>
-            </tr>
-          </ng-template>
-        </p-table>
+        <joshies-duels-table [duels]="duels" [editable]="true" />
       } @else {
         <p class="my-12 py-12 text-center text-neutral-500 italic">
           No duels for this turn
@@ -96,6 +58,7 @@ import { DuelTableAvatarsComponent } from '../../shared/ui/duel-table-avatars.co
           label="Proceed to Chaos Space Event Phase"
           styleClass="w-full mt-4"
           (onClick)="proceedToChaosSpaceEventPhase()"
+          [loading]="proceedingToNextPhase()"
         />
       }
     } @else {
@@ -122,7 +85,7 @@ export default class ResolveDuelsPageComponent {
 
   readonly roundNumber = this.gameStateService.roundNumber;
 
-  proceedingToNextPhase = signal(false);
+  readonly proceedingToNextPhase = signal(false);
 
   proceedToChaosSpaceEventPhase(): void {
     confirmBackendAction({

--- a/src/app/gm-tools/ui/can-cancel-duel.pipe.ts
+++ b/src/app/gm-tools/ui/can-cancel-duel.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DuelModel } from '../../shared/util/supabase-types';
+import { DuelStatus } from '../../shared/util/supabase-helpers';
+
+@Pipe({
+  name: 'canCancelDuel',
+  standalone: true,
+})
+export class CanCancelDuelPipe implements PipeTransform {
+  transform(duel: DuelModel): boolean {
+    return (
+      duel.status === DuelStatus.OpponentNotSelected ||
+      duel.status === DuelStatus.WagerNotSelected ||
+      duel.status === DuelStatus.GameNotSelected ||
+      duel.status === DuelStatus.WaitingToBegin
+    );
+  }
+}

--- a/src/app/gm-tools/ui/duels-table.component.ts
+++ b/src/app/gm-tools/ui/duels-table.component.ts
@@ -1,0 +1,110 @@
+import { Component, inject, input, signal } from '@angular/core';
+import { DuelTableAvatarsComponent } from '../../shared/ui/duel-table-avatars.component';
+import { RouterLink } from '@angular/router';
+import { StatusTagComponent } from './status-tag.component';
+import { StronglyTypedTableRowDirective } from '../../shared/ui/strongly-typed-table-row.directive';
+import { TableModule } from 'primeng/table';
+import { FormsModule } from '@angular/forms';
+import { AvatarModule } from 'primeng/avatar';
+import { DuelModel } from '../../shared/util/supabase-types';
+import { DuelStatus, trackById } from '../../shared/util/supabase-helpers';
+import { ButtonModule } from 'primeng/button';
+import { DuelService } from '../../shared/data-access/duel.service';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { confirmBackendAction } from '../../shared/util/dialog-helpers';
+
+@Component({
+  selector: 'joshies-duels-table',
+  template: ` <p-table [value]="duels()" [rowTrackBy]="trackById">
+    <ng-template #header>
+      <tr>
+        <th class="pr-0">Players</th>
+        <th>Game</th>
+        <th class="px-0 text-right">Status</th>
+        @if (cancelable()) {
+          <th class="px-0"></th>
+        }
+        @if (editable()) {
+          <th class="px-0"></th>
+        }
+      </tr>
+    </ng-template>
+
+    <ng-template #body let-duel [joshiesStronglyTypedTableRow]="duels()">
+      <tr [routerLink]="editable() ? [duel.id] : null">
+        <td class="pr-0">
+          <joshies-duel-table-avatars [duel]="duel" />
+        </td>
+        <td class="text-sm">
+          {{ duel.game_name }}
+        </td>
+        <td class="px-0 text-right">
+          <joshies-status-tag [status]="duel.status" />
+        </td>
+        @if (cancelable()) {
+          <td class="w-0 px-1 text-right">
+            <p-button
+              icon="pi pi-times"
+              severity="danger"
+              label="Cancel"
+              [disabled]="!duelCancelable(duel)"
+              (click)="confirmCancelDuel(duel)"
+              [loading]="cancelingDuel()"
+            />
+          </td>
+        }
+        @if (editable()) {
+          <td class="px-1">
+            <i class="pi pi-angle-right text-neutral-400"></i>
+          </td>
+        }
+      </tr>
+    </ng-template>
+  </p-table>`,
+  imports: [
+    AvatarModule,
+    FormsModule,
+    TableModule,
+    StronglyTypedTableRowDirective,
+    StatusTagComponent,
+    RouterLink,
+    DuelTableAvatarsComponent,
+    ButtonModule,
+  ],
+})
+export class DuelsTableComponent {
+  private readonly duelService = inject(DuelService);
+  private readonly confirmationService = inject(ConfirmationService);
+  private readonly messageService = inject(MessageService);
+
+  readonly duels = input.required<DuelModel[]>();
+  readonly editable = input<boolean>(false);
+  readonly cancelable = input<boolean>(false);
+
+  readonly trackById = trackById;
+  readonly cancelingDuel = signal<boolean>(false);
+
+  duelCancelable(duel: DuelModel): boolean {
+    return (
+      duel.status === DuelStatus.OpponentNotSelected ||
+      duel.status === DuelStatus.WagerNotSelected ||
+      duel.status === DuelStatus.GameNotSelected ||
+      duel.status === DuelStatus.WaitingToBegin
+    );
+  }
+  confirmCancelDuel(duel: DuelModel): void {
+    const confirmationMessage = duel.opponent
+      ? `Are you sure you want to cancel this duel between ${duel.challenger?.display_name} and ${duel.opponent.display_name}? This cannot be undone.`
+      : `Are you sure you want to cancel this duel for ${duel.challenger?.display_name}? This cannot be undone.`;
+
+    confirmBackendAction({
+      action: async () => this.duelService.cancelDuel(duel.id),
+      confirmationMessageText: confirmationMessage,
+      successMessageText: 'Duel canceled',
+      submittingSignal: this.cancelingDuel,
+      confirmationService: this.confirmationService,
+      messageService: this.messageService,
+      successNavigation: null,
+    });
+  }
+}

--- a/src/app/gm-tools/ui/duels-table.component.ts
+++ b/src/app/gm-tools/ui/duels-table.component.ts
@@ -7,11 +7,12 @@ import { TableModule } from 'primeng/table';
 import { FormsModule } from '@angular/forms';
 import { AvatarModule } from 'primeng/avatar';
 import { DuelModel } from '../../shared/util/supabase-types';
-import { DuelStatus, trackById } from '../../shared/util/supabase-helpers';
+import { trackById } from '../../shared/util/supabase-helpers';
 import { ButtonModule } from 'primeng/button';
 import { DuelService } from '../../shared/data-access/duel.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { confirmBackendAction } from '../../shared/util/dialog-helpers';
+import { CanCancelDuelPipe } from './can-cancel-duel.pipe';
 
 @Component({
   selector: 'joshies-duels-table',
@@ -47,7 +48,7 @@ import { confirmBackendAction } from '../../shared/util/dialog-helpers';
               icon="pi pi-times"
               severity="danger"
               label="Cancel"
-              [disabled]="!duelCancelable(duel)"
+              [disabled]="!(duel | canCancelDuel)"
               (click)="confirmCancelDuel(duel)"
               [loading]="cancelingDuel()"
             />
@@ -70,6 +71,7 @@ import { confirmBackendAction } from '../../shared/util/dialog-helpers';
     RouterLink,
     DuelTableAvatarsComponent,
     ButtonModule,
+    CanCancelDuelPipe,
   ],
 })
 export class DuelsTableComponent {
@@ -84,14 +86,6 @@ export class DuelsTableComponent {
   readonly trackById = trackById;
   readonly cancelingDuel = signal<boolean>(false);
 
-  duelCancelable(duel: DuelModel): boolean {
-    return (
-      duel.status === DuelStatus.OpponentNotSelected ||
-      duel.status === DuelStatus.WagerNotSelected ||
-      duel.status === DuelStatus.GameNotSelected ||
-      duel.status === DuelStatus.WaitingToBegin
-    );
-  }
   confirmCancelDuel(duel: DuelModel): void {
     const confirmationMessage = duel.opponent
       ? `Are you sure you want to cancel this duel between ${duel.challenger?.display_name} and ${duel.opponent.display_name}? This cannot be undone.`

--- a/src/app/gm-tools/ui/new-duel.component.ts
+++ b/src/app/gm-tools/ui/new-duel.component.ts
@@ -1,10 +1,9 @@
 import {
   Component,
   computed,
-  effect,
   inject,
   input,
-  OnInit,
+  linkedSignal,
   output,
   signal,
 } from '@angular/core';
@@ -120,7 +119,7 @@ import { ActivatedRoute, Router } from '@angular/router';
     Button,
   ],
 })
-export default class NewDuelComponent implements OnInit {
+export default class NewDuelComponent {
   private readonly gameboardService = inject(GameboardService);
   private readonly playerService = inject(PlayerService);
   private readonly duelService = inject(DuelService);
@@ -135,10 +134,20 @@ export default class NewDuelComponent implements OnInit {
   readonly submitted = output<void>();
 
   readonly players = this.playerService.players;
-  readonly selectedChallenger = signal<PlayerWithUserAndRankInfo | null>(null);
   readonly selectedOpponent = signal<PlayerWithUserAndRankInfo | null>(null);
-  readonly selectedDuelSpace = signal<GameboardSpaceModel | null>(null);
   readonly submitting = signal(false);
+
+  readonly selectedChallenger = linkedSignal<PlayerWithUserAndRankInfo | null>(
+    () => {
+      const challenger = this.challenger();
+      return challenger ? challenger : null;
+    },
+  );
+
+  readonly selectedDuelSpace = linkedSignal<GameboardSpaceModel | null>(() => {
+    const duelSpaces = this.duelSpaces();
+    return duelSpaces.length > 0 ? duelSpaces[0] : null;
+  });
 
   readonly submitButtonDisabled = computed(() => {
     const challenger = this.selectedChallenger();
@@ -189,22 +198,6 @@ export default class NewDuelComponent implements OnInit {
       successNavigation: inline ? '' : '..',
       activatedRoute: this.activatedRoute,
       router: this.router,
-    });
-  }
-
-  ngOnInit(): void {
-    const challenger = this.challenger();
-    if (challenger) {
-      this.selectedChallenger.set(challenger);
-    }
-  }
-
-  constructor() {
-    effect(() => {
-      const duelSpaces = this.duelSpaces();
-      if (duelSpaces && duelSpaces.length > 0) {
-        this.selectedDuelSpace.set(duelSpaces[0]);
-      }
     });
   }
 }

--- a/src/app/gm-tools/ui/new-duel.component.ts
+++ b/src/app/gm-tools/ui/new-duel.component.ts
@@ -1,0 +1,210 @@
+import {
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  OnInit,
+  output,
+  signal,
+} from '@angular/core';
+import { CardComponent } from '../../shared/ui/card.component';
+import { Select } from 'primeng/select';
+import { AvatarModule } from 'primeng/avatar';
+import { DecimalPipe } from '@angular/common';
+import {
+  PlayerService,
+  PlayerWithUserAndRankInfo,
+} from '../../shared/data-access/player.service';
+import { FormsModule } from '@angular/forms';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { GameboardService } from '../../shared/data-access/gameboard.service';
+import { GameboardSpaceModel } from '../../shared/util/supabase-types';
+import { Button } from 'primeng/button';
+import { DuelService } from '../../shared/data-access/duel.service';
+import { confirmBackendAction } from '../../shared/util/dialog-helpers';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'joshies-new-duel',
+  template: ` <div class="mt-4 flex flex-col gap-4">
+    <joshies-card padded styleClass="flex flex-col gap-4">
+      <label class="flex flex-col gap-2" [class.hidden]="challenger()">
+        Challenger
+        <p-select
+          [options]="players()"
+          [(ngModel)]="selectedChallenger"
+          styleClass="flex"
+          placeholder="Select a challenger"
+        >
+          <ng-template #item let-player>
+            <div class="flex items-center gap-2">
+              <p-avatar
+                [image]="player.avatar_url"
+                shape="circle"
+                styleClass="h-6 w-6"
+              />
+              {{ player.display_name }} ({{ player.score | number }} points)
+            </div>
+          </ng-template>
+          <ng-template #selectedItem let-player>
+            <div class="flex items-center gap-2">
+              <p-avatar
+                [image]="player.avatar_url"
+                shape="circle"
+                styleClass="h-6 w-6"
+              />
+              {{ player.display_name }} ({{ player.score | number }} points)
+            </div>
+          </ng-template>
+        </p-select>
+      </label>
+      <label class="flex flex-col gap-2">
+        Opponent
+        <p-select
+          [options]="players()"
+          [(ngModel)]="selectedOpponent"
+          styleClass="flex"
+          placeholder="Select an opponent"
+        >
+          <ng-template #item let-player>
+            <div class="flex items-center gap-2">
+              <p-avatar
+                [image]="player.avatar_url"
+                shape="circle"
+                styleClass="h-6 w-6"
+              />
+              {{ player.display_name }} ({{ player.score | number }} points)
+            </div>
+          </ng-template>
+          <ng-template #selectedItem let-player>
+            <div class="flex items-center gap-2">
+              <p-avatar
+                [image]="player.avatar_url"
+                shape="circle"
+                styleClass="h-6 w-6"
+              />
+              {{ player.display_name }} ({{ player.score | number }} points)
+            </div>
+          </ng-template>
+        </p-select>
+      </label>
+      <label
+        class="flex flex-col gap-2"
+        [class.hidden]="duelSpaces().length === 1"
+      >
+        Duel Space Type
+        <p-select
+          placeholder="Duel Spaces"
+          [options]="duelSpaces()"
+          optionLabel="name"
+          [(ngModel)]="selectedDuelSpace"
+        />
+      </label>
+    </joshies-card>
+    <p-button
+      label="Create Duel"
+      styleClass="w-full mt-2"
+      (onClick)="confirmSubmit()"
+      [disabled]="submitButtonDisabled()"
+      [loading]="submitting()"
+    />
+  </div>`,
+  imports: [
+    CardComponent,
+    Select,
+    AvatarModule,
+    DecimalPipe,
+    FormsModule,
+    Button,
+  ],
+})
+export default class NewDuelComponent implements OnInit {
+  private readonly gameboardService = inject(GameboardService);
+  private readonly playerService = inject(PlayerService);
+  private readonly duelService = inject(DuelService);
+  private readonly confirmationService = inject(ConfirmationService);
+  private readonly messageService = inject(MessageService);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  readonly challenger = input<PlayerWithUserAndRankInfo | null>(null);
+  readonly inline = input<boolean>(false);
+
+  readonly submitted = output<void>();
+
+  readonly players = this.playerService.players;
+  readonly selectedChallenger = signal<PlayerWithUserAndRankInfo | null>(null);
+  readonly selectedOpponent = signal<PlayerWithUserAndRankInfo | null>(null);
+  readonly selectedDuelSpace = signal<GameboardSpaceModel | null>(null);
+  readonly submitting = signal(false);
+
+  readonly submitButtonDisabled = computed(() => {
+    const challenger = this.selectedChallenger();
+    const opponent = this.selectedOpponent();
+    const duelSpace = this.selectedDuelSpace();
+    return (
+      !challenger || !duelSpace || challenger.player_id === opponent?.player_id
+    );
+  });
+
+  private readonly gameboardSpaces = toSignal(
+    this.gameboardService.gameboardSpaces$,
+  );
+
+  readonly duelSpaces = computed(() => {
+    const spaces = this.gameboardSpaces();
+    return spaces?.filter((space) => space.effect === 'duel') || [];
+  });
+
+  confirmSubmit() {
+    if (this.submitButtonDisabled()) {
+      return;
+    }
+
+    const selectedChallenger = this.selectedChallenger();
+    const selectedOpponent = this.selectedOpponent();
+    const selectedDuelSpace = this.selectedDuelSpace();
+    const inline = this.inline();
+
+    const confirmationMessage = selectedOpponent
+      ? `Are you sure you want to create a duel between ${selectedChallenger?.display_name} and ${selectedOpponent.display_name}?`
+      : `Are you sure you want to create a duel for ${selectedChallenger?.display_name}?`;
+
+    confirmBackendAction({
+      action: async () => {
+        this.submitted.emit();
+        return this.duelService.createDuel(
+          selectedChallenger!.player_id,
+          selectedDuelSpace!.id,
+          selectedOpponent?.player_id,
+        );
+      },
+      confirmationMessageText: confirmationMessage,
+      successMessageText: 'Duel created',
+      submittingSignal: this.submitting,
+      confirmationService: this.confirmationService,
+      messageService: this.messageService,
+      successNavigation: inline ? '' : '..',
+      activatedRoute: this.activatedRoute,
+      router: this.router,
+    });
+  }
+
+  ngOnInit(): void {
+    const challenger = this.challenger();
+    if (challenger) {
+      this.selectedChallenger.set(challenger);
+    }
+  }
+
+  constructor() {
+    effect(() => {
+      const duelSpaces = this.duelSpaces();
+      if (duelSpaces && duelSpaces.length > 0) {
+        this.selectedDuelSpace.set(duelSpaces[0]);
+      }
+    });
+  }
+}

--- a/src/app/shared/data-access/game-state.service.ts
+++ b/src/app/shared/data-access/game-state.service.ts
@@ -124,6 +124,34 @@ export class GameStateService {
       .update(partialGameState)
       .eq('id', 1);
   }
+
+  roundPhaseOrderIndex(roundPhase: RoundPhase): number {
+    switch (roundPhase) {
+      case RoundPhase.GameboardMoves:
+        return 0;
+      case RoundPhase.SpecialSpaceEvents:
+        return 1;
+      case RoundPhase.Duels:
+        return 2;
+      case RoundPhase.ChaosSpaceEvents:
+        return 3;
+      case RoundPhase.Event:
+        return 4;
+      case RoundPhase.WaitingForNextRound:
+        return 5;
+    }
+  }
+
+  phaseIsOver(roundPhase: RoundPhase): boolean | null {
+    const currentRoundPhase = this.roundPhase();
+    if (!currentRoundPhase) {
+      return null;
+    }
+    return (
+      this.roundPhaseOrderIndex(currentRoundPhase) >
+      this.roundPhaseOrderIndex(roundPhase)
+    );
+  }
 }
 
 function createSelector<

--- a/src/app/shared/util/dialog-helpers.ts
+++ b/src/app/shared/util/dialog-helpers.ts
@@ -6,9 +6,17 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { PostgrestSingleResponse } from '@supabase/supabase-js';
 import { FunctionsResponse } from '@supabase/functions-js';
 
+export type LocalErrorResponse = {
+  error: {
+    message: string;
+  };
+};
+
 export type ConfirmBackendActionConfig = {
   action: () => Promise<
-    PostgrestSingleResponse<unknown> | FunctionsResponse<unknown>
+    | PostgrestSingleResponse<unknown>
+    | FunctionsResponse<unknown>
+    | LocalErrorResponse
   >;
   confirmationHeaderText?: string;
   confirmationMessageText?: string;


### PR DESCRIPTION
Closes #87 

Creates a "Manage Duels" gm tool to allow creating/cancelling duels manually at any time. Also allows creating duels from the "Enter Gameboard Moves" page.